### PR TITLE
SCRUM-8-Debug-script-runner-console

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,12 @@ project/assembly_name="CaveGame"
 
 [input]
 
+ui_text_newline={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194309,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194310,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 player_jump={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
@@ -46,6 +52,11 @@ player_move_right={
 DEBUG_takeDamage={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+debug_console={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":96,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/interface.tscn
+++ b/scenes/interface.tscn
@@ -1,9 +1,15 @@
-[gd_scene load_steps=5 format=3 uid="uid://jxyevycakmnv"]
+[gd_scene load_steps=7 format=3 uid="uid://jxyevycakmnv"]
 
 [ext_resource type="PackedScene" uid="uid://du07qhtteauuh" path="res://assets/interface/hp_bar.tscn" id="1_wpx7d"]
 [ext_resource type="PackedScene" uid="uid://mkc0o25ok023" path="res://assets/interface/mana_bar.tscn" id="2_juv2u"]
 [ext_resource type="Script" path="res://scripts/DebugConsole/debug_console.gd" id="3_0x6lf"]
 [ext_resource type="Script" path="res://scripts/DebugConsole/command_box.gd" id="4_6ncm3"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kvi75"]
+bg_color = Color(1, 0.247466, 0.652583, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4iq1j"]
+bg_color = Color(0, 0, 0, 1)
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -29,21 +35,33 @@ layout_mode = 2
 [node name="ManaBar" parent="Interface2/VBoxContainer" instance=ExtResource("2_juv2u")]
 layout_mode = 2
 
-[node name="DebugConsole" type="VBoxContainer" parent="."]
+[node name="DebugConsole" type="VBoxContainer" parent="." node_paths=PackedStringArray("LogOutput")]
 process_mode = 3
 visible = false
-anchors_preset = 15
+anchors_preset = 12
+anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_top = -696.0
 grow_horizontal = 2
-grow_vertical = 2
+grow_vertical = 0
 alignment = 2
 script = ExtResource("3_0x6lf")
+LogOutput = NodePath("Background/Log")
 
-[node name="Log" type="RichTextLabel" parent="DebugConsole"]
+[node name="Background" type="ColorRect" parent="DebugConsole"]
 layout_mode = 2
+color = Color(0, 0, 0, 0.498039)
+
+[node name="Log" type="RichTextLabel" parent="DebugConsole/Background"]
+layout_mode = 2
+offset_right = 1280.0
+offset_bottom = 230.0
+theme_override_styles/fill = SubResource("StyleBoxFlat_kvi75")
+theme_override_styles/background = SubResource("StyleBoxFlat_4iq1j")
 bbcode_enabled = true
 fit_content = true
+shortcut_keys_enabled = false
 
 [node name="Command" type="TextEdit" parent="DebugConsole"]
 layout_mode = 2

--- a/scenes/interface.tscn
+++ b/scenes/interface.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://jxyevycakmnv"]
+[gd_scene load_steps=4 format=3 uid="uid://jxyevycakmnv"]
 
 [ext_resource type="PackedScene" uid="uid://du07qhtteauuh" path="res://assets/interface/hp_bar.tscn" id="1_wpx7d"]
 [ext_resource type="PackedScene" uid="uid://mkc0o25ok023" path="res://assets/interface/mana_bar.tscn" id="2_juv2u"]
+[ext_resource type="Script" path="res://scripts/debug_console.gd" id="3_0x6lf"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -26,3 +27,24 @@ layout_mode = 2
 
 [node name="ManaBar" parent="Interface2/VBoxContainer" instance=ExtResource("2_juv2u")]
 layout_mode = 2
+
+[node name="DebugConsole" type="VBoxContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 2
+script = ExtResource("3_0x6lf")
+
+[node name="Log" type="RichTextLabel" parent="DebugConsole"]
+layout_mode = 2
+bbcode_enabled = true
+text = "testa aaaaaaa"
+fit_content = true
+
+[node name="Command" type="TextEdit" parent="DebugConsole"]
+layout_mode = 2
+text = "asdasd"
+placeholder_text = "asdasd"
+scroll_fit_content_height = true

--- a/scenes/interface.tscn
+++ b/scenes/interface.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://jxyevycakmnv"]
+[gd_scene load_steps=5 format=3 uid="uid://jxyevycakmnv"]
 
 [ext_resource type="PackedScene" uid="uid://du07qhtteauuh" path="res://assets/interface/hp_bar.tscn" id="1_wpx7d"]
 [ext_resource type="PackedScene" uid="uid://mkc0o25ok023" path="res://assets/interface/mana_bar.tscn" id="2_juv2u"]
-[ext_resource type="Script" path="res://scripts/debug_console.gd" id="3_0x6lf"]
+[ext_resource type="Script" path="res://scripts/DebugConsole/debug_console.gd" id="3_0x6lf"]
+[ext_resource type="Script" path="res://scripts/DebugConsole/command_box.gd" id="4_6ncm3"]
 
 [node name="CanvasLayer" type="CanvasLayer"]
 
@@ -48,3 +49,4 @@ fit_content = true
 layout_mode = 2
 placeholder_text = "Write GDScript here"
 scroll_fit_content_height = true
+script = ExtResource("4_6ncm3")

--- a/scenes/interface.tscn
+++ b/scenes/interface.tscn
@@ -29,6 +29,8 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="DebugConsole" type="VBoxContainer" parent="."]
+process_mode = 3
+visible = false
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -40,11 +42,9 @@ script = ExtResource("3_0x6lf")
 [node name="Log" type="RichTextLabel" parent="DebugConsole"]
 layout_mode = 2
 bbcode_enabled = true
-text = "testa aaaaaaa"
 fit_content = true
 
 [node name="Command" type="TextEdit" parent="DebugConsole"]
 layout_mode = 2
-text = "asdasd"
-placeholder_text = "asdasd"
+placeholder_text = "Write GDScript here"
 scroll_fit_content_height = true

--- a/scripts/DebugConsole/command_box.gd
+++ b/scripts/DebugConsole/command_box.gd
@@ -1,0 +1,23 @@
+extends TextEdit
+
+var DbgConsole: DebugConsole;
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	DbgConsole = get_parent()
+	pass # Replace with function body.
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_up") and get_caret_line() == 0:
+		print("going to older line")
+		DbgConsole.historyPos += 1
+		text = DbgConsole.history[DbgConsole.historyPos]
+	if event.is_action_pressed("ui_down") and get_caret_line() == get_line_count()-1:
+		print("going to newer line")
+		DbgConsole.historyPos -= 1
+		text = DbgConsole.history[DbgConsole.historyPos]
+	pass
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/scripts/DebugConsole/command_box.gd
+++ b/scripts/DebugConsole/command_box.gd
@@ -9,13 +9,11 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_up") and get_caret_line() == 0:
-		print("going to older line")
 		DbgConsole.historyPos += 1
-		text = DbgConsole.history[DbgConsole.historyPos]
+		text = DbgConsole.get_curr_history()
 	if event.is_action_pressed("ui_down") and get_caret_line() == get_line_count()-1:
-		print("going to newer line")
 		DbgConsole.historyPos -= 1
-		text = DbgConsole.history[DbgConsole.historyPos]
+		text = DbgConsole.get_curr_history()
 	pass
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/scripts/DebugConsole/debug_console.gd
+++ b/scripts/DebugConsole/debug_console.gd
@@ -1,5 +1,23 @@
+class_name DebugConsole
 extends Control
 
+var history = [ "" ]
+var historyPos = 0:
+	get:
+		return historyPos;
+	set(value):
+		if value > history.size()-1:
+			historyPos = history.size()-1
+		elif value < 0:
+			historyPos = 0
+		else:
+			historyPos = value
+
+func add_to_history(text: String) -> void:
+	history.push_front(text)
+	if history.size() > 20:
+		history.pop_back()
+	pass
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -33,6 +51,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	elif event.is_action_pressed("ui_accept") and visible:
 		print("running script")
 		eval_code($Command.text)
+		add_to_history($Command.text)
 		get_tree().paused = false
 		hide()
 		return

--- a/scripts/DebugConsole/debug_console.gd
+++ b/scripts/DebugConsole/debug_console.gd
@@ -1,6 +1,8 @@
 class_name DebugConsole
 extends Control
 
+@export var LogOutput: RichTextLabel
+
 var history = [ "" ]
 var historyPos = 0:
 	get:
@@ -8,8 +10,8 @@ var historyPos = 0:
 	set(value):
 		if value > history.size()-1:
 			historyPos = history.size()-1
-		elif value < 0:
-			historyPos = 0
+		elif value < -1:
+			historyPos = -1
 		else:
 			historyPos = value
 
@@ -19,9 +21,21 @@ func add_to_history(text: String) -> void:
 		history.pop_back()
 	pass
 
+func append_text(text: String) -> void:
+	LogOutput.append_text(text + "\n");
+	$Background.custom_minimum_size.y = LogOutput.get_content_height()
+	pass
+
+func get_curr_history() -> String:
+	if historyPos < 0:
+		return ""
+	else:
+		return history[historyPos]
+	pass
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	Log.LogObject = $Log
+	Log.LogObject = self
 	pass # Replace with function body.
 
 func eval_code(code):
@@ -38,20 +52,19 @@ func eval_code(code):
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("debug_console") and not visible:
-		print("opening console")
 		get_tree().paused = true
 		show()
 		$Command.grab_focus()
 		return
 	elif event.is_action_pressed("ui_cancel") and visible:
-		print("closing console")
 		get_tree().paused = false
 		hide()
 		return
 	elif event.is_action_pressed("ui_accept") and visible:
-		print("running script")
 		eval_code($Command.text)
 		add_to_history($Command.text)
+		historyPos = -1
+		$Command.text = ""
 		get_tree().paused = false
 		hide()
 		return
@@ -60,7 +73,7 @@ func _unhandled_input(event: InputEvent) -> void:
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
-	if visible:
-		$Log.offset_bottom = $Command.get_line_height()
-		$Log.size.y = $Log.get_content_height()
+	#if visible:
+		#$Background/Log.offset_bottom = $Command.get_line_height()
+		#$Background/Log.size.y = $Background/Log.get_content_height()
 	pass

--- a/scripts/DebugConsole/debug_console.gd
+++ b/scripts/DebugConsole/debug_console.gd
@@ -48,7 +48,8 @@ func eval_code(code):
 	script.reload()
 	var var_root = get_tree().root
 	var var_player = var_root.find_child("Player", true, false)
-	return script._eval(var_root, var_player)
+	if script.has_method("_eval"):
+		return script._eval(var_root, var_player)
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("debug_console") and not visible:
@@ -61,7 +62,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		hide()
 		return
 	elif event.is_action_pressed("ui_accept") and visible:
-		eval_code($Command.text)
+		Log.info(eval_code($Command.text))
 		add_to_history($Command.text)
 		historyPos = -1
 		$Command.text = ""

--- a/scripts/Log.gd
+++ b/scripts/Log.gd
@@ -4,6 +4,7 @@ extends Object
 static var log = ""
 static var LogObject: RichTextLabel
 
-static func info(msg: String):
-	LogObject.append_text("\n" + msg);
+static func info(msg):
+	LogObject.append_text("\n" + str(msg));
+	print(str(msg))
 	pass

--- a/scripts/Log.gd
+++ b/scripts/Log.gd
@@ -1,0 +1,9 @@
+class_name Log
+extends Object
+
+static var log = ""
+static var LogObject: RichTextLabel
+
+static func info(msg: String):
+	LogObject.append_text("\n" + msg);
+	pass

--- a/scripts/Log.gd
+++ b/scripts/Log.gd
@@ -2,9 +2,9 @@ class_name Log
 extends Object
 
 static var log = ""
-static var LogObject: RichTextLabel
+static var LogObject: Control
 
 static func info(msg):
-	LogObject.append_text("\n" + str(msg));
+	LogObject.append_text(str(msg));
 	print(str(msg))
 	pass

--- a/scripts/Log.gd
+++ b/scripts/Log.gd
@@ -5,6 +5,7 @@ static var log = ""
 static var LogObject: Control
 
 static func info(msg):
-	LogObject.append_text(str(msg));
-	print(str(msg))
+	if msg != null:
+		LogObject.append_text(str(msg));
+		print(str(msg))
 	pass

--- a/scripts/debug_console.gd
+++ b/scripts/debug_console.gd
@@ -1,0 +1,42 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	Log.LogObject = $Log
+	pass # Replace with function body.
+
+func eval_code(code):
+	var script = GDScript.new()
+	script.source_code += "extends Node\n"
+	script.source_code += "static func _eval():\n\tpass"
+	for line in code.split("\n"):
+		script.source_code += "\n\t" + line
+	# Reload the script since setting the source_code doesn't recompile it, according to the docs
+	script.reload()
+	return script._eval()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("debug_console") and not visible:
+		print("opening console")
+		show()
+		$Command.grab_focus()
+		return
+	elif event.is_action_pressed("ui_cancel") and visible:
+		print("closing console")
+		hide()
+		return
+	elif event.is_action_pressed("ui_accept") and visible:
+		print("running script")
+		eval_code($Command.text)
+		hide()
+		return
+	if visible:
+		get_viewport().set_input_as_handled()
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	if visible:
+		$Log.offset_bottom = $Command.get_line_height()
+		$Log.size.y = $Log.get_content_height()
+	pass

--- a/scripts/debug_console.gd
+++ b/scripts/debug_console.gd
@@ -9,26 +9,31 @@ func _ready() -> void:
 func eval_code(code):
 	var script = GDScript.new()
 	script.source_code += "extends Node\n"
-	script.source_code += "static func _eval():\n\tpass"
+	script.source_code += "static func _eval(root: Node, player: Node2D):\n\tpass"
 	for line in code.split("\n"):
 		script.source_code += "\n\t" + line
 	# Reload the script since setting the source_code doesn't recompile it, according to the docs
 	script.reload()
-	return script._eval()
+	var var_root = get_tree().root
+	var var_player = var_root.find_child("Player", true, false)
+	return script._eval(var_root, var_player)
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("debug_console") and not visible:
 		print("opening console")
+		get_tree().paused = true
 		show()
 		$Command.grab_focus()
 		return
 	elif event.is_action_pressed("ui_cancel") and visible:
 		print("closing console")
+		get_tree().paused = false
 		hide()
 		return
 	elif event.is_action_pressed("ui_accept") and visible:
 		print("running script")
 		eval_code($Command.text)
+		get_tree().paused = false
 		hide()
 		return
 	if visible:

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -77,9 +77,7 @@ func _physics_process(delta: float) -> void:
 		current_hp -= 5
 		current_mana -= 5
 		print("Current hp: ", current_hp, "; Current mana: ", current_mana)
-	
-	
-	
+
 	# Add the gravity.
 	if not is_on_floor():
 		velocity += get_gravity() * delta


### PR DESCRIPTION
The user can open the debug console via the ~ key (backtick). Doing so pauses the entire game except the debug console to prevent accidental inputs. To execute the code the user has to press the **Enter** key, to exit the console the user has to press the **Escape** key. The history works, keeping track of the last 20 executions. Multi-line support is built into the TextEdit node so it was already working.
I've created a `Log` static class so we can have a unified logging to the engine console and the game's debug console, as the game has no access to the engine's logging console.