### PR TITLE
SCRUM-35-Fix-the-melee-attack

### DIFF
--- a/scripts/Entity.gd
+++ b/scripts/Entity.gd
@@ -3,15 +3,20 @@ class_name Entity
 extends Node2D
 
 @export var maxHealth: float = 1
+@export var maxInvincibilityFrames: int = 10;
 # Replace with a property later, when implementing target dummies
 var health: float
+var invincibilityFrames: int = 0;
 
 # OVERRIDE THIS IN CLASSES THAT INHERIT THIS CLASS FOR PROPER FUNCTIONALITY
 func Damage(damage: float, source: Node2D):
+	if invincibilityFrames > 0:
+		return;
 	health -= damage;
 	var tween = get_tree().create_tween()
 	tween.tween_property(self, "modulate", Color.RED, 0.05);
 	tween.tween_property(self, "modulate", Color.WHITE, 0.05);
+	invincibilityFrames = maxInvincibilityFrames;
 	Log.info(name + " took " + str(damage) + " damage, health left: " + str(health))
 	pass
 
@@ -22,5 +27,7 @@ func _ready() -> void:
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
+func _physics_process(delta: float) -> void:
+	if invincibilityFrames > 0:
+		invincibilityFrames -= 1;
 	pass

--- a/scripts/target_dummy.gd
+++ b/scripts/target_dummy.gd
@@ -1,6 +1,8 @@
 extends Entity
 
 func Damage(damage: float, source: Node2D):
+	if invincibilityFrames > 0:
+		return;
 	#Log.info("dummy got hit by " + source.name + " for " + str(damage) + " damage, health left: " + str(health))
 	var force = (($body.global_position - source.global_position) as Vector2).normalized() * damage * 50
 	$body.apply_impulse(force)
@@ -12,12 +14,9 @@ func Damage(damage: float, source: Node2D):
 	tween.tween_property(self, "modulate", Color.RED, 0.05);
 	tween.tween_property(self, "modulate", Color.WHITE, 0.05);
 	$Hurt.play()
+	invincibilityFrames = maxInvincibilityFrames;
 	pass
 
 func _timer_end() -> void:
 	$Damage.text = ""
-	pass
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
 	pass


### PR DESCRIPTION
The invincibility frames were added to the base entity class so that any entity can have the maximum amount of invincibility frames adjusted per entity basis. The default amount of invincibility frames is set to 10. Also removed some unneeded code from target dummy and base entity class.