### PR TITLE
Minor bugfixes

### DIFF
--- a/entities/Entity.gd
+++ b/entities/Entity.gd
@@ -5,7 +5,15 @@ extends Node2D
 @export var maxHealth: float = 1
 @export var maxInvincibilityFrames: int = 10;
 # Replace with a property later, when implementing target dummies
-var health: float
+var health: float:
+	get:
+		return health;
+	set(value):
+		if value < minHealth:
+			health = minHealth;
+			return;
+		health = value;
+
 var minHealth: float = 0
 var invincibilityFrames: int = 0;
 

--- a/entities/Entity.gd
+++ b/entities/Entity.gd
@@ -10,7 +10,7 @@ extends Node2D
 		return health;
 	set(value):
 		health = value;
-		if value < minHealth:
+		if value <= minHealth:
 			handleDeath()
 			return;
 
@@ -34,7 +34,6 @@ func Damage(damage: float, source: Node2D):
 
 # OVERRIDE THIS IN CLASSES WHICH MIGHT DIE IN MORE UNIQUE WAYS
 func handleDeath():
-	health = minHealth
 	Log.info(name + " died")
 	self.queue_free()	# Remove the current object from the game
 	

--- a/entities/Entity.gd
+++ b/entities/Entity.gd
@@ -44,6 +44,4 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
 	if invincibilityFrames > 0:
 		invincibilityFrames -= 1;
-	if health <= minHealth:
-		handleDeath()
 	pass

--- a/entities/Entity.gd
+++ b/entities/Entity.gd
@@ -3,19 +3,22 @@ class_name Entity
 extends Node2D
 
 @export var maxHealth: float = 1
-@export var maxInvincibilityFrames: int = 10;
-# Replace with a property later, when implementing target dummies
-var health: float:
+@export var minHealth: float = 0
+
+@onready var health: float = maxHealth:
 	get:
 		return health;
 	set(value):
-		if value < minHealth:
-			health = minHealth;
-			return;
 		health = value;
+		if value < minHealth:
+			handleDeath()
+			return;
 
-var minHealth: float = 0
+@export var maxInvincibilityFrames: int = 10;
 var invincibilityFrames: int = 0;
+
+func _init() -> void:
+	health = maxHealth
 
 # OVERRIDE THIS IN CLASSES THAT INHERIT THIS CLASS FOR PROPER FUNCTIONALITY
 func Damage(damage: float, source: Node2D):

--- a/entities/goblin/damageHandler.gd
+++ b/entities/goblin/damageHandler.gd
@@ -2,19 +2,25 @@ extends Entity
 
 signal goblin_died
 
+var parent: Node2D
+
+func _ready() -> void:
+	parent = get_parent()
+	Log.info(health)
+
 func Damage(damage: float, source: Node2D):
 	if invincibilityFrames > 0:
 		return;
 	health -= damage;
 	var tween = get_tree().create_tween()
-	tween.tween_property(self, "modulate", Color.RED, 0.05);
-	tween.tween_property(self, "modulate", Color.WHITE, 0.05);
+	tween.tween_property(parent, "modulate", Color.RED, 0.05);
+	tween.tween_property(parent, "modulate", Color.WHITE, 0.05);
 	invincibilityFrames = maxInvincibilityFrames;
 	Log.info(name + " took " + str(damage) + " damage, health left: " + str(health))
 	pass
 
 func handleDeath():
-	health = minHealth
+	#health = minHealth
 	
 	goblin_died.emit()
 	

--- a/entities/goblin/goblin.gd
+++ b/entities/goblin/goblin.gd
@@ -43,6 +43,10 @@ func move(delta):
 	if !dead:
 		# The goblin is wandering around
 		if !is_goblin_chase:
+			if player_in_area:
+				velocity.x = 0
+				return
+			
 			# If the ground detector has detected floor in front of us, we can move
 			if (groundDetection.has_overlapping_bodies() or groundDetection_Deep.has_overlapping_bodies()):
 				# If the goblin touches a wall, he should try to jump
@@ -120,3 +124,15 @@ func chose(array: Array):
 func _on_damage_handler_goblin_died() -> void:
 	Log.info(name + " died")
 	self.queue_free()
+
+
+func _on_player_reached(body: Node2D) -> void:
+	Log.info("Player approached")
+	player_in_area = true
+	pass # Replace with function body.
+
+
+func _on_player_left(body: Node2D) -> void:
+	Log.info("Player left")
+	player_in_area = false
+	pass # Replace with function body.

--- a/entities/goblin/goblin.gd
+++ b/entities/goblin/goblin.gd
@@ -22,6 +22,18 @@ var is_roaming: bool = true
 var player: CharacterBody2D
 var player_in_area: bool = false
 
+var rng: RandomNumberGenerator;
+var receivedGoblinInstruction = false
+enum GoblinInstruction {
+	None, Switch
+}
+var goblinInstruction: GoblinInstruction = GoblinInstruction.None
+
+
+func _ready() -> void:
+	rng = RandomNumberGenerator.new()
+	
+
 func _physics_process(delta: float) -> void:
 	if not is_on_floor():
 		velocity += get_gravity() * delta
@@ -121,18 +133,41 @@ func chose(array: Array):
 	array.shuffle()
 	return array.front()
 
+func receive_goblin_instruction(instruction: GoblinInstruction, sender: Node2D):
+	Log.info(name + " received instruction. " + str(GoblinInstruction.keys()[instruction]) + " from " + sender.name)
+	receivedGoblinInstruction = true;
+	match instruction:
+		GoblinInstruction.Switch:
+			dir.x *= -1;
+	pass
+
 func _on_damage_handler_goblin_died() -> void:
 	Log.info(name + " died")
 	self.queue_free()
 
 
-func _on_player_reached(body: Node2D) -> void:
-	Log.info("Player approached")
-	player_in_area = true
+func _on_entity_reached(body: Node2D) -> void:
+	if body == self:
+		return
+	if body is PlayerCharacter:
+		Log.info("Player approached")
+		player_in_area = true
+	elif body is Goblin_Enemy:
+		dir.x *= -1;
+		#if !receivedGoblinInstruction:
+			#var instr: GoblinInstruction = GoblinInstruction.Switch #rng.randi_range(1,2)
+			#body.receive_goblin_instruction(instr, self)
+			#match instr:
+				#GoblinInstruction.JumpOver:
+					#return;
+		pass
 	pass # Replace with function body.
 
 
-func _on_player_left(body: Node2D) -> void:
-	Log.info("Player left")
-	player_in_area = false
+func _on_entity_left(body: Node2D) -> void:
+	if body is PlayerCharacter:
+		Log.info("Player left")
+		player_in_area = false
+	elif body is Goblin_Enemy:
+		pass
 	pass # Replace with function body.

--- a/entities/goblin/goblin.tscn
+++ b/entities/goblin/goblin.tscn
@@ -58,9 +58,10 @@ size = Vector2(8, 8)
 size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5svo4"]
-size = Vector2(10, 30)
+size = Vector2(3, 30)
 
 [node name="Goblin" type="CharacterBody2D" node_paths=PackedStringArray("directionFlip", "groundDetection", "groundDetection_Deep", "jumpBlockDetection")]
+collision_layer = 4
 script = ExtResource("1_w1pob")
 directionFlip = NodePath("directionFlip")
 groundDetection = NodePath("directionFlip/GroundDetector")
@@ -127,15 +128,16 @@ visible = false
 z_index = 2
 texture = SubResource("PlaceholderTexture2D_fthgw")
 
-[node name="PlayerDetector" type="Area2D" parent="directionFlip"]
-position = Vector2(-11, 0)
+[node name="EntityDetector" type="Area2D" parent="directionFlip"]
+position = Vector2(-11, -1)
 collision_layer = 0
-collision_mask = 2
+collision_mask = 6
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="directionFlip/PlayerDetector"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="directionFlip/EntityDetector"]
+position = Vector2(-2, 1)
 shape = SubResource("RectangleShape2D_5svo4")
 
 [connection signal="goblin_died" from="DamageHandler" to="." method="_on_damage_handler_goblin_died"]
 [connection signal="timeout" from="DirectionTimer" to="." method="_on_direction_timer_timeout"]
-[connection signal="body_entered" from="directionFlip/PlayerDetector" to="." method="_on_player_reached"]
-[connection signal="body_exited" from="directionFlip/PlayerDetector" to="." method="_on_player_left"]
+[connection signal="body_entered" from="directionFlip/EntityDetector" to="." method="_on_entity_reached"]
+[connection signal="body_exited" from="directionFlip/EntityDetector" to="." method="_on_entity_left"]

--- a/entities/goblin/goblin.tscn
+++ b/entities/goblin/goblin.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://bnrfrkdsmnw48"]
+[gd_scene load_steps=13 format=3 uid="uid://bnrfrkdsmnw48"]
 
 [ext_resource type="Script" uid="uid://bnoebxhe6p0o1" path="res://entities/goblin/damageHandler.gd" id="1_fthgw"]
 [ext_resource type="Script" uid="uid://207uwl76xuo2" path="res://entities/goblin/goblin.gd" id="1_w1pob"]
@@ -56,6 +56,9 @@ size = Vector2(8, 8)
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_fthgw"]
 size = Vector2(8, 8)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_5svo4"]
+size = Vector2(10, 30)
 
 [node name="Goblin" type="CharacterBody2D" node_paths=PackedStringArray("directionFlip", "groundDetection", "groundDetection_Deep", "jumpBlockDetection")]
 script = ExtResource("1_w1pob")
@@ -124,5 +127,15 @@ visible = false
 z_index = 2
 texture = SubResource("PlaceholderTexture2D_fthgw")
 
+[node name="PlayerDetector" type="Area2D" parent="directionFlip"]
+position = Vector2(-11, 0)
+collision_layer = 0
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="directionFlip/PlayerDetector"]
+shape = SubResource("RectangleShape2D_5svo4")
+
 [connection signal="goblin_died" from="DamageHandler" to="." method="_on_damage_handler_goblin_died"]
 [connection signal="timeout" from="DirectionTimer" to="." method="_on_direction_timer_timeout"]
+[connection signal="body_entered" from="directionFlip/PlayerDetector" to="." method="_on_player_reached"]
+[connection signal="body_exited" from="directionFlip/PlayerDetector" to="." method="_on_player_left"]

--- a/scenes/MenuScenes/MainMenu/main_menu.gd
+++ b/scenes/MenuScenes/MainMenu/main_menu.gd
@@ -9,6 +9,7 @@ func _on_play_pressed() -> void:
 func _on_options_pressed() -> void:
 	if not get_node_or_null("settings"):  # Prevent multiple instances
 		var settings_instance = settings_scene.instantiate()
+		settings_instance.shouldBlur = false;
 		add_child(settings_instance)  # Adds it as a child
 	
 

--- a/scenes/MenuScenes/SettingsScreen/input_button.tscn
+++ b/scenes/MenuScenes/SettingsScreen/input_button.tscn
@@ -16,23 +16,17 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 3
 theme_override_constants/margin_bottom = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
-layout_mode = 2
-
-[node name="LabelAction" type="Label" parent="MarginContainer/HBoxContainer"]
+[node name="LabelAction" type="Label" parent="MarginContainer"]
 layout_mode = 2
 mouse_filter = 1
 theme_override_font_sizes/font_size = 25
 text = "Key"
 vertical_alignment = 1
 
-[node name="Spacer" type="Control" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="LabelInput" type="Label" parent="MarginContainer/HBoxContainer"]
+[node name="LabelInput" type="Label" parent="MarginContainer"]
 layout_mode = 2
 mouse_filter = 1
 theme_override_font_sizes/font_size = 25
 text = "Input"
+horizontal_alignment = 2
 vertical_alignment = 1

--- a/scenes/MenuScenes/SettingsScreen/settings.gd
+++ b/scenes/MenuScenes/SettingsScreen/settings.gd
@@ -3,36 +3,44 @@ extends Control
 const resolutions = [ Vector2i(1920,1080), Vector2i(1600,900), Vector2i(1280,720) ]
 
 @onready var input_button_scene = preload("uid://bthc5hdvcfj20")
-@onready var action_list = $PanelContainer/VBoxContainer/ScrollContainer/ActionList
+@onready var action_list = %ActionList
 
 var is_remaping = false
 var action_to_remap = null
 var remapping_button = null
+var shouldBlur = true
+
 var input_actions = {
 	"player_jump" : "Jump",
 	"player_move_left" : "Move left",
 	"player_move_right" : "Move right",
-	"player_attack" : "Attack",
+	"player_attack_melee" : "Melee Attack",
+	"player_attack_ranged" : "Ranged Attack",
+	"player_interact" : "Interact",
 	"player_dash" : "Dash"
 }
+
 func resume():
 	$AnimationPlayer.play_backwards("Blur")
 
 func pause():
-	$AnimationPlayer.play("Blur")
+	if shouldBlur:
+		$AnimationPlayer.play("Blur")
+	else:
+		$AnimationPlayer.play("NoBlur")
 	
 func _ready():
-	$PanelContainer/VBoxContainer/Volume.value = AudioServer.get_bus_volume_linear(0)*100
-	$"PanelContainer/VBoxContainer/Mute sound".button_pressed = AudioServer.is_bus_mute(0)
+	%Volume.value = AudioServer.get_bus_volume_linear(0)*100
+	%"Mute sound".button_pressed = AudioServer.is_bus_mute(0)
 	
 	_create_action_list()
 	
 	for resolution in resolutions:
-		$PanelContainer/VBoxContainer/Resolutions.add_item(str(resolution.x)+"x"+str(resolution.y))
+		%Resolutions.add_item(str(resolution.x)+"x"+str(resolution.y))
 	var size = DisplayServer.window_get_size(0)
 	var idx = resolutions.find(size)
 	if idx > -1:
-		$PanelContainer/VBoxContainer/Resolutions.selected = idx;
+		%Resolutions.selected = idx;
 
 	pause()
 
@@ -86,7 +94,7 @@ func _on_input_button_pressed(button, action):
 		action_to_remap = action
 		remapping_button = button
 		button.find_child("LabelInput").text = "Press key to bind..."
-				
+
 func _input(event):
 	if is_remaping:
 		if(

--- a/scenes/MenuScenes/SettingsScreen/settings.gd
+++ b/scenes/MenuScenes/SettingsScreen/settings.gd
@@ -106,4 +106,5 @@ func _update_action_list(button, event):
 
 
 func _on_reset_pressed() -> void:
+	InputMap.load_from_project_settings()
 	_create_action_list()

--- a/scenes/MenuScenes/SettingsScreen/settings.tscn
+++ b/scenes/MenuScenes/SettingsScreen/settings.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://bxnqjli45gx2e"]
+[gd_scene load_steps=10 format=3 uid="uid://bxnqjli45gx2e"]
 
 [ext_resource type="Script" uid="uid://dmf1mpipau60a" path="res://scenes/MenuScenes/SettingsScreen/settings.gd" id="1_5p8wc"]
 [ext_resource type="Shader" uid="uid://bus8qxo8npi86" path="res://shaders/blur.gdshader" id="2_r6d6q"]
@@ -7,6 +7,9 @@
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_6wm04"]
 shader = ExtResource("2_r6d6q")
 shader_parameter/lod = 0.0
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1hw7a"]
+bg_color = Color(0.169245, 0.169245, 0.169245, 1)
 
 [sub_resource type="Animation" id="Animation_7l7mv"]
 resource_name = "Blur"
@@ -26,7 +29,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("PanelContainer:modulate")
+tracks/1/path = NodePath("MarginContainer/PanelContainer:modulate")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -47,6 +50,18 @@ tracks/2/keys = {
 "update": 1,
 "values": [false, true, true]
 }
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/PanelContainer:theme_override_styles/panel:bg_color")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(0.17, 0.17, 0.17, 0.498039), Color(0.17, 0.17, 0.17, 0.498039)]
+}
 
 [sub_resource type="Animation" id="Animation_v4r4p"]
 length = 0.001
@@ -65,7 +80,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("PanelContainer:modulate")
+tracks/1/path = NodePath("MarginContainer/PanelContainer:modulate")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -86,10 +101,75 @@ tracks/2/keys = {
 "update": 1,
 "values": [false]
 }
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/PanelContainer:theme_override_styles/panel:bg_color")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(0.169245, 0.169245, 0.169245, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_uh7bu"]
+resource_name = "NoBlur"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("ColorRect:material:shader_parameter/lod")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(),
+"transitions": PackedFloat32Array(),
+"update": 0,
+"values": []
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("MarginContainer/PanelContainer:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.012, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 1,
+"values": [false, true, true]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/PanelContainer:theme_override_styles/panel:bg_color")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(0.17, 0.17, 0.17, 1), Color(0.17, 0.17, 0.17, 1)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_1s2dm"]
 _data = {
 &"Blur": SubResource("Animation_7l7mv"),
+&"NoBlur": SubResource("Animation_uh7bu"),
 &"RESET": SubResource("Animation_v4r4p")
 }
 
@@ -113,81 +193,100 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="."]
-modulate = Color(1, 1, 1, 0)
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 64
+theme_override_constants/margin_top = 64
+theme_override_constants/margin_right = 64
+theme_override_constants/margin_bottom = 64
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_1hw7a")
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 
-[node name="Volume2" type="Label" parent="PanelContainer/VBoxContainer"]
+[node name="Volume2" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Adjust Volume"
 
-[node name="Volume" type="HSlider" parent="PanelContainer/VBoxContainer"]
+[node name="Volume" type="HSlider" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Volume3" type="Label" parent="PanelContainer/VBoxContainer"]
+[node name="Volume3" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "
 Mute sound"
 
-[node name="Mute sound" type="CheckBox" parent="PanelContainer/VBoxContainer"]
+[node name="Mute sound" type="CheckBox" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Volume4" type="Label" parent="PanelContainer/VBoxContainer"]
+[node name="Volume4" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "
 Adjust resolution"
 
-[node name="Resolutions" type="OptionButton" parent="PanelContainer/VBoxContainer"]
+[node name="Resolutions" type="OptionButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 process_mode = 3
 layout_mode = 2
 
-[node name="exit settings" type="Button" parent="PanelContainer/VBoxContainer"]
+[node name="exit settings" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 25
 text = "Exit Settings"
 
-[node name="Reset" type="Button" parent="PanelContainer/VBoxContainer"]
+[node name="Reset" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 focus_mode = 0
 theme_override_font_sizes/font_size = 25
 text = "Reset"
 
-[node name="Spacer" type="Label" parent="PanelContainer/VBoxContainer"]
+[node name="Spacer" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="ScrollContainer" type="ScrollContainer" parent="PanelContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="ActionList" type="VBoxContainer" parent="PanelContainer/VBoxContainer/ScrollContainer"]
+[node name="ActionList" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="InputButton" parent="PanelContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
+[node name="InputButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
 layout_mode = 2
 
-[node name="InputButton2" parent="PanelContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
+[node name="InputButton2" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
 layout_mode = 2
 
-[node name="InputButton3" parent="PanelContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
+[node name="InputButton3" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
 layout_mode = 2
 
-[node name="InputButton4" parent="PanelContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
+[node name="InputButton4" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
 layout_mode = 2
 
-[node name="InputButton5" parent="PanelContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
+[node name="InputButton5" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
 layout_mode = 2
 
-[node name="InputButton6" parent="PanelContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
+[node name="InputButton6" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer/ActionList" instance=ExtResource("3_6wm04")]
 layout_mode = 2
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -195,8 +294,8 @@ libraries = {
 &"": SubResource("AnimationLibrary_1s2dm")
 }
 
-[connection signal="value_changed" from="PanelContainer/VBoxContainer/Volume" to="." method="_on_volume_value_changed"]
-[connection signal="toggled" from="PanelContainer/VBoxContainer/Mute sound" to="." method="_on_mute_sound_toggled"]
-[connection signal="item_selected" from="PanelContainer/VBoxContainer/Resolutions" to="." method="_on_resolutions_item_selected"]
-[connection signal="pressed" from="PanelContainer/VBoxContainer/exit settings" to="." method="_on_exit_settings_pressed"]
-[connection signal="pressed" from="PanelContainer/VBoxContainer/Reset" to="." method="_on_reset_pressed"]
+[connection signal="value_changed" from="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/Volume" to="." method="_on_volume_value_changed"]
+[connection signal="toggled" from="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/Mute sound" to="." method="_on_mute_sound_toggled"]
+[connection signal="item_selected" from="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/Resolutions" to="." method="_on_resolutions_item_selected"]
+[connection signal="pressed" from="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/exit settings" to="." method="_on_exit_settings_pressed"]
+[connection signal="pressed" from="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/Reset" to="." method="_on_reset_pressed"]

--- a/scenes/MenuScenes/SettingsScreen/settings.tscn
+++ b/scenes/MenuScenes/SettingsScreen/settings.tscn
@@ -63,57 +63,6 @@ tracks/3/keys = {
 "values": [Color(0.17, 0.17, 0.17, 0.498039), Color(0.17, 0.17, 0.17, 0.498039)]
 }
 
-[sub_resource type="Animation" id="Animation_v4r4p"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("ColorRect:material:shader_parameter/lod")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [0.0]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("MarginContainer/PanelContainer:modulate")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Color(1, 1, 1, 0)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath(".:visible")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("MarginContainer/PanelContainer:theme_override_styles/panel:bg_color")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Color(0.169245, 0.169245, 0.169245, 1)]
-}
-
 [sub_resource type="Animation" id="Animation_uh7bu"]
 resource_name = "NoBlur"
 length = 0.3
@@ -164,6 +113,57 @@ tracks/3/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Color(0.17, 0.17, 0.17, 1), Color(0.17, 0.17, 0.17, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_v4r4p"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("ColorRect:material:shader_parameter/lod")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("MarginContainer/PanelContainer:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/PanelContainer:theme_override_styles/panel:bg_color")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(0.169245, 0.169245, 0.169245, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_1s2dm"]

--- a/scenes/interface/interface.tscn
+++ b/scenes/interface/interface.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="PackedScene" uid="uid://du07qhtteauuh" path="res://scenes/interface/hp_bar.tscn" id="1_wpx7d"]
 [ext_resource type="PackedScene" uid="uid://mkc0o25ok023" path="res://scenes/interface/mana_bar.tscn" id="2_juv2u"]
 [ext_resource type="Script" uid="uid://cqswot2ewonva" path="res://scenes/debug_console/debug_console.gd" id="3_0x6lf"]
-[ext_resource type="Script" path="res://scenes/interface/WeaponSelectionScreen.gd" id="3_7i0gs"]
+[ext_resource type="Script" uid="uid://ceqabomyba6px" path="res://scenes/interface/WeaponSelectionScreen.gd" id="3_7i0gs"]
 [ext_resource type="PackedScene" uid="uid://dn8amu36njlul" path="res://scenes/MenuScenes/PauseMenu/pause_menu.tscn" id="3_qqekr"]
 [ext_resource type="Script" uid="uid://e2eyy28mds0i" path="res://scenes/debug_console/command_box.gd" id="4_6ncm3"]
 [ext_resource type="Resource" uid="uid://c2qj0falsfk2y" path="res://weapons/weapons_table.tres" id="4_tf5yn"]

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -1775,7 +1775,7 @@ position = Vector2(0, 0)
 scale = Vector2(0.999844, 0.999844)
 
 [node name="head" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset" index="0"]
-rotation = -0.00580464
+rotation = -0.00580466
 scale = Vector2(0.999857, 0.999857)
 
 [node name="shoulder_r" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset" index="1"]
@@ -1783,10 +1783,12 @@ rotation = 1.93946
 scale = Vector2(0.999991, 0.999991)
 
 [node name="forearm_r" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset/shoulder_r" index="1"]
-rotation = -0.833526
+rotation = -0.833528
+scale = Vector2(0.999999, 0.999999)
 
 [node name="shoulder_f" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset" index="2"]
 rotation = 2.43437
+scale = Vector2(0.999985, 0.999985)
 
 [node name="forearm_f" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset/shoulder_f" index="1"]
 rotation = -1.73952
@@ -1803,12 +1805,12 @@ rotation = -0.276292
 scale = Vector2(0.99984, 0.99984)
 
 [node name="Forearm_R" parent="GameObjects/Player/sprites" index="0"]
-position = Vector2(-2.91475, -0.926952)
+position = Vector2(-2.91473, -0.926945)
 rotation = -0.464865
 
 [node name="Shoulder_R" parent="GameObjects/Player/sprites" index="1"]
-position = Vector2(-3.80116, -9.83456)
-rotation = 0.368662
+position = Vector2(-3.80115, -9.83456)
+rotation = 0.36866
 
 [node name="Calf_B" parent="GameObjects/Player/sprites" index="2"]
 position = Vector2(3.67006, 14.0344)
@@ -1831,7 +1833,7 @@ position = Vector2(-5.2769, -28.0557)
 
 [node name="Head" parent="GameObjects/Player/sprites" index="7"]
 position = Vector2(-1.54036, -20.4958)
-rotation = -0.00580464
+rotation = -0.00580463
 
 [node name="FrontHair" parent="GameObjects/Player/sprites" index="8"]
 position = Vector2(-6.51007, -26.1904)
@@ -1840,12 +1842,12 @@ position = Vector2(-6.51007, -26.1904)
 position = Vector2(0, -7.99875)
 
 [node name="FlipHandler" parent="GameObjects/Player/sprites" index="11"]
-position = Vector2(-1.34702, -2.63909)
-rotation = -0.875946
+position = Vector2(-1.34702, -2.6391)
+rotation = -0.875947
 
 [node name="Forearm_F" parent="GameObjects/Player/sprites" index="12"]
 position = Vector2(-5.43985, -5.18505)
-rotation = -0.875946
+rotation = -0.875947
 
 [node name="Shoulder_F" parent="GameObjects/Player/sprites" index="13"]
 position = Vector2(-5.79976, -11.2497)
@@ -1986,6 +1988,10 @@ tile_set = SubResource("TileSet_ev07y")
 collision_enabled = false
 
 [node name="Interface" parent="." instance=ExtResource("6_raeie")]
+
+[node name="PauseMenu" parent="Interface" index="2"]
+offset_top = 0.0
+offset_bottom = 0.0
 
 [editable path="GameObjects/Player"]
 [editable path="Interface"]

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -1398,8 +1398,7 @@ texture = ExtResource("16_hxu8e")
 3:1/0 = 0
 
 [sub_resource type="TileSet" id="TileSet_nvumn"]
-physics_layer_0/collision_layer = 3
-physics_layer_0/collision_mask = 3
+physics_layer_0/collision_layer = 1
 terrain_set_0/mode = 1
 terrain_set_0/terrain_0/name = "Ground"
 terrain_set_0/terrain_0/color = Color(0.5, 0.34375, 0.25, 1)
@@ -1784,11 +1783,9 @@ scale = Vector2(0.999991, 0.999991)
 
 [node name="forearm_r" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset/shoulder_r" index="1"]
 rotation = -0.833528
-scale = Vector2(0.999999, 0.999999)
 
 [node name="shoulder_f" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset" index="2"]
 rotation = 2.43437
-scale = Vector2(0.999985, 0.999985)
 
 [node name="forearm_f" parent="GameObjects/Player/Skeleton/hip/torso/collar/offset/shoulder_f" index="1"]
 rotation = -1.73952
@@ -1805,12 +1802,12 @@ rotation = -0.276292
 scale = Vector2(0.99984, 0.99984)
 
 [node name="Forearm_R" parent="GameObjects/Player/sprites" index="0"]
-position = Vector2(-2.91473, -0.926945)
+position = Vector2(-2.91475, -0.926952)
 rotation = -0.464865
 
 [node name="Shoulder_R" parent="GameObjects/Player/sprites" index="1"]
-position = Vector2(-3.80115, -9.83456)
-rotation = 0.36866
+position = Vector2(-3.80116, -9.83456)
+rotation = 0.368663
 
 [node name="Calf_B" parent="GameObjects/Player/sprites" index="2"]
 position = Vector2(3.67006, 14.0344)
@@ -1829,25 +1826,25 @@ position = Vector2(1.13631, 5.77062)
 rotation = -0.276292
 
 [node name="BHair" parent="GameObjects/Player/sprites" index="6"]
-position = Vector2(-5.2769, -28.0557)
+position = Vector2(-5.2769, -28.0556)
 
 [node name="Head" parent="GameObjects/Player/sprites" index="7"]
-position = Vector2(-1.54036, -20.4958)
-rotation = -0.00580463
+position = Vector2(-1.54036, -20.4957)
+rotation = -0.00580464
 
 [node name="FrontHair" parent="GameObjects/Player/sprites" index="8"]
-position = Vector2(-6.51007, -26.1904)
+position = Vector2(-6.51007, -26.1903)
 
 [node name="Torso" parent="GameObjects/Player/sprites" index="9"]
 position = Vector2(0, -7.99875)
 
 [node name="FlipHandler" parent="GameObjects/Player/sprites" index="11"]
-position = Vector2(-1.34702, -2.6391)
-rotation = -0.875947
+position = Vector2(-1.34702, -2.63909)
+rotation = -0.875946
 
 [node name="Forearm_F" parent="GameObjects/Player/sprites" index="12"]
 position = Vector2(-5.43985, -5.18505)
-rotation = -0.875947
+rotation = -0.875946
 
 [node name="Shoulder_F" parent="GameObjects/Player/sprites" index="13"]
 position = Vector2(-5.79976, -11.2497)

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -1808,7 +1808,7 @@ rotation = -0.464865
 
 [node name="Shoulder_R" parent="GameObjects/Player/sprites" index="1"]
 position = Vector2(-3.80116, -9.83456)
-rotation = 0.368663
+rotation = 0.368662
 
 [node name="Calf_B" parent="GameObjects/Player/sprites" index="2"]
 position = Vector2(3.67006, 14.0344)
@@ -1827,14 +1827,14 @@ position = Vector2(1.13631, 5.77062)
 rotation = -0.276292
 
 [node name="BHair" parent="GameObjects/Player/sprites" index="6"]
-position = Vector2(-5.2769, -28.0555)
+position = Vector2(-5.2769, -28.0557)
 
 [node name="Head" parent="GameObjects/Player/sprites" index="7"]
-position = Vector2(-1.54036, -20.4956)
-rotation = -0.00580459
+position = Vector2(-1.54036, -20.4958)
+rotation = -0.00580464
 
 [node name="FrontHair" parent="GameObjects/Player/sprites" index="8"]
-position = Vector2(-6.51007, -26.1902)
+position = Vector2(-6.51007, -26.1904)
 
 [node name="Torso" parent="GameObjects/Player/sprites" index="9"]
 position = Vector2(0, -7.99875)


### PR DESCRIPTION
Fixes bugs:
* SCRUM-62 Fix settings screen reset keybinds button not working: Applied the fix from the description
* SCRUM-72 Fix settings screen: When opening the settings screen from the main menu, it has an opaque background, also added padding to the settings so it doesn't take up the whole screen and added missing keybinds.
* SCRUM-68 Replace health variable with a property in Entity.gd: Did as the bug suggests, removed a redundant check in `_physics_process` death checking, also allowed the health go below the minimum amount as that happening shouldn't really impact anything? Besides that, removed the health getting set to its minimum value on death as to prevent an infinite recursion loop.
* SCRUM-69 Goblin should flash red whenever it takes damage: Changed the modulation from being applied to `self` to the parent of the `damageHandler` node, which is the goblin
* SCRUM-70 Player able to rest when not in safe area: The issue was caused because of the terrain residing in not only it's own layer, but also the player's physics layer, causing the interaction listener to think that the terrain was a player. Fixed by simply removing the terrain from the player's physics layer.
* SCRUM-63 Fix goblin always having pushing priority: Made the player not have any collisions with the goblin itself and also make the goblin stop once it approaches a player.
* SCRUM-71 Fix goblin navigation: The goblins now when they reach each other, one of them (or both) should change their directions.